### PR TITLE
bind to address

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ const EventEmitter = require('events').EventEmitter
 const DNSParse = require('./parse')
 
 
-module.exports.createServer = (port = 53) => {
+module.exports.createServer = (port = 53, addr = '127.0.0.1') => {
 
     let dnsServerEvent = new EventEmitter()
     this.server = dgram.createSocket('udp4')
@@ -58,7 +58,7 @@ module.exports.createServer = (port = 53) => {
 
     })
 
-    this.server.bind(port)
+    this.server.bind(port, addr)
     
     return dnsServerEvent
 


### PR DESCRIPTION
Allow binding to a specific address.  Services such as dnsmasq often bind to 127.0.0.1:53, this will allow a user to bind to their external address, or a different loopback (127.0.0.2).  I did this for my dev environment.  I have the updns bound to 127.0.0.2, with a regex pattern match so I don't have to add a bunch of entries to my hosts file.  I updated my dns settings to point to 127.0.0.2, and have the script running in PM2, works like a champ.  I have the default set as 127.0.0.1 so it's fully backwards compatible, no breaking changes.