### PR TITLE
bind to address

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ const EventEmitter = require('events').EventEmitter
 const DNSParse = require('./parse')
 
 
-module.exports.createServer = (port = 53, addr = '127.0.0.1') => {
+module.exports.createServer = (port = 53, addr) => {
 
     let dnsServerEvent = new EventEmitter()
     this.server = dgram.createSocket('udp4')
@@ -58,7 +58,11 @@ module.exports.createServer = (port = 53, addr = '127.0.0.1') => {
 
     })
 
-    this.server.bind(port, addr)
+    if (addr) {
+      this.server.bind(port, addr)
+    } else {
+      this.server.bind(port)
+    }
     
     return dnsServerEvent
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ const EventEmitter = require('events').EventEmitter
 const DNSParse = require('./parse')
 
 
-module.exports.createServer = (port = 53) => {
+module.exports.createServer = (port = 53, addr = '127.0.0.1') => {
 
     let dnsServerEvent = new EventEmitter()
     this.server = dgram.createSocket('udp4')
@@ -58,7 +58,7 @@ module.exports.createServer = (port = 53) => {
 
     })
 
-    this.server.bind(port)
+    this.server.bind(port, addr)
     
     return dnsServerEvent
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,9 +59,9 @@ module.exports.createServer = (port = 53, addr) => {
     })
 
     if (addr) {
-      this.server.bind(port, addr)
+        this.server.bind(port, addr)
     } else {
-      this.server.bind(port)
+        this.server.bind(port)
     }
     
     return dnsServerEvent


### PR DESCRIPTION
Allow binding to a specific address.  Services such as dnsmasq and ssystemd-resolved often bind to port 53, this will allow a user to bind to their external address, (or any valid loopback: 127.x.x.x).

I did this for my dev environment.  I have updns bound to 127.0.0.2, and I updated my dns settings to point to 127.0.0.2, and have the script running in PM2, works like a champ.  Without this change, any other process using port 53 (bound to any address) will cause NodeJS to throw an exception about the port already in use.  This allows the user to bind to a specific address.