### PR TITLE
global install update: bind param in hosts, watch hosts for changes, regex RFC update, support regex hosts

### DIFF
--- a/bin/service.js
+++ b/bin/service.js
@@ -58,7 +58,7 @@ Add a correct proxy address: "proxy 8.8.8.8"`
 }
 
 
-const updns = require('./../lib').createServer(53)
+const updns = require('./../lib').createServer(bind.port, bind.address)
 const domainEvent = new EventEmitter()
 
 hosts.forEach(host => {

--- a/bin/service.js
+++ b/bin/service.js
@@ -6,6 +6,10 @@ const EventEmitter = require('events').EventEmitter
 const hostsConfigPath = path.join(__dirname, './../config/hosts')
 
 
+var bind = {
+  address: null,
+  port: 53
+}
 const proxy = []
 const hosts
     =

--- a/bin/service.js
+++ b/bin/service.js
@@ -28,6 +28,7 @@ const hosts
             if(binding){
               bind.address = (binding[1] === '0.0.0.0') ? null : binding[1]
               bind.port = (binding[2] <= 65535) ? binding[2] : bind.port
+              writeLog(`Updns has bound to interface ${bind.address || '0.0.0.0(ANY/ALL)'} on port ${bind.port}`)
               return false
             }
 

--- a/bin/service.js
+++ b/bin/service.js
@@ -22,6 +22,15 @@ const hosts
                 return false
             }
 
+            // bind    127.0.0.3:53    # listen-address : port
+            let bindReg = /^bind\s+((?:25[0-5]|2[0-4]\d|1\d\d|\d{1,2})(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|\d{1,2})){3})(?::(\d{1,5}))?\s*#?.*$/
+            let binding = bindReg.exec(host)
+            if(binding){
+              bind.address = (binding[1] === '0.0.0.0') ? null : binding[1]
+              bind.port = (binding[2] <= 65535) ? binding[2] : bind.port
+              return false
+            }
+
             // proxy    8.8.8.8    # proxy => ip
             let proxyReg = /^\s*proxy\s+((\d{1,2}|1\d\d|2[0-4]\d|25[0-5])(\.(\d{1,2}|1\d\d|2[0-4]\d|25[0-5])){3})(\s*|\s+#.*)$/
             if(proxyReg.test(host)){

--- a/bin/service.js
+++ b/bin/service.js
@@ -23,7 +23,7 @@ const hosts
             }
 
             // bind    127.0.0.3:53    # listen-address : port
-            let bindReg = /^bind\s+((?:25[0-5]|2[0-4]\d|1\d\d|\d{1,2})(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|\d{1,2})){3})(?::(\d{1,5}))?\s*#?.*$/
+            let bindReg = /^\s*bind\s+((?:25[0-5]|2[0-4]\d|1\d\d|\d{1,2})(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|\d{1,2})){3})(?::(\d{1,5}))?\s*#?.*$/
             let binding = bindReg.exec(host)
             if(binding){
               bind.address = (binding[1] === '0.0.0.0') ? null : binding[1]

--- a/config/hosts
+++ b/config/hosts
@@ -1,9 +1,10 @@
 
 
-bind            0.0.0.0:53 # IP => Port
-proxy           8.8.8.8    # proxy => DNS Server
+bind                0.0.0.0:53     # address => port
+proxy               8.8.8.8        # proxy => DNS Server
 
-# google.com    1.1.1.1    # domain => IP
-# yahoo.com     2.2.2.2
+# google.com        1.1.1.1        # domain => IP
+# yahoo.com         2.2.2.2
 
+# /goo+gle\.com/    127.99.99.99   # regex: anything.gooooooooooogle.com => IP
 

--- a/config/hosts
+++ b/config/hosts
@@ -6,5 +6,5 @@ proxy               8.8.8.8        # proxy => DNS Server
 # google.com        1.1.1.1        # domain => IP
 # yahoo.com         2.2.2.2
 
-# /goo+gle\.com/    127.99.99.99   # regex: anything.gooooooooooogle.com => IP
+# /goo+gle-\.com/   3.3.3.3        # regex: gooooooooooogle.com => IP
 

--- a/config/hosts
+++ b/config/hosts
@@ -1,5 +1,6 @@
 
 
+bind            0.0.0.0:53 # IP => Port
 proxy           8.8.8.8    # proxy => DNS Server
 
 # google.com    1.1.1.1    # domain => IP

--- a/config/hosts
+++ b/config/hosts
@@ -6,5 +6,5 @@ proxy               8.8.8.8        # proxy => DNS Server
 # google.com        1.1.1.1        # domain => IP
 # yahoo.com         2.2.2.2
 
-# /goo+gle-\.com/   3.3.3.3        # regex: gooooooooooogle.com => IP
+# /goo+gle\.com/    3.3.3.3        # regex: gooooooooooogle.com => IP
 


### PR DESCRIPTION
I committed in small batches to make it easy(ier) for you to follow along.
There are comments in the code, as well as on the larger (and less obvious) commits.
I rebased it from your recent changes, so if you like what you see, it should be an easy merge.

1.  Specify bind parameters in the hosts/config file.
1.  Watches & automatically loads changes to the `hosts` file.
1.  Did my best to adhere to RFC spec for domain name matching, updated the regex.
1.  Allow regular expressions in the `hosts` file (requests are still validated to RFC spec).